### PR TITLE
missing words list bug fixed

### DIFF
--- a/sinr/text/evaluate.py
+++ b/sinr/text/evaluate.py
@@ -195,7 +195,7 @@ def eval_similarity(sinr_vec, dataset, print_missing=True):
             else:
                 vec2 = vec_mean
                 if dataset.X[i][1] not in missing_words:
-                    missing_words.append(dataset.X[i][0])
+                    missing_words.append(dataset.X[i][1])
         else:
             vec2 = sinr_vec._get_vector(sinr_vec._get_index(dataset.X[i][1]))
         


### PR DESCRIPTION
**Description**

if dataset.X[i][1] not in missing_words:
missing_words.append(dataset.X[i][0])
Line 198 of evaluate.txt

changed into

if dataset.X[i][1] not in missing_words:
missing_words.append(dataset.X[i][1])
Line 198 of evaluate.txt

Fixes issue Evaluate text method : missing words list #67 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update