### PR TITLE
load_from_word2vec model s name bug fixed

### DIFF
--- a/sinr/graph_embeddings.py
+++ b/sinr/graph_embeddings.py
@@ -621,7 +621,7 @@ class SINrVectors(object):
             i+=1
         file.close()
         
-        model = cls("bnc_sg_exceptions_gs", n_jobs=n_jobs, n_neighbors=n_neighbors)
+        model = cls(name, n_jobs=n_jobs, n_neighbors=n_neighbors)
         model.set_vocabulary(vocabulary)
         rows, cols, vals = zip(*vectors)
         matrix = csr_matrix((vals, (rows, cols)))


### PR DESCRIPTION
**Description**

Corrected the name of the model in the method load_from_word2vec (graph_embeddings)

Fixes (issue)  Wrong model's name in load_from_w2v from graph_embeddings #69 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update