### PR TITLE
73 wrong community memberships update when filtering dimensions

### DIFF
--- a/sinr/graph_embeddings.py
+++ b/sinr/graph_embeddings.py
@@ -1,7 +1,7 @@
 import pickle as pk
 
 from networkit import Graph, components, community, setNumberOfThreads, getCurrentNumberOfThreads, getMaxNumberOfThreads, Partition
-from numpy import argpartition, argsort, asarray, where, nonzero, concatenate, repeat, mean, nanmax, int64
+from numpy import argpartition, argsort, asarray, where, nonzero, concatenate, repeat, mean, nanmax, int64, shape
 from sklearn.neighbors import NearestNeighbors
 from scipy import spatial
 from scipy.sparse import csr_matrix
@@ -870,13 +870,16 @@ class SINrVectors(object):
                 for i in tqdm(sorted(ind_max + ind_min, reverse = True)):
                     self.communities_sets.pop(i)
 
-                # Update the communities members
-                self.community_membership = set()
-
-                for c in self.communities_sets:
-                    self.community_membership = self.community_membership.union(c)
-
-                self.community_membership = sorted(list(self.community_membership))
+            # Update of the community membership for each word of the vocabulary
+            self.community_membership = list()
+            for w in range(shape(self.vocab)[0]):
+                found = 0
+                for i, com in enumerate(self.communities_sets):
+                    if w in com:
+                        self.community_membership.append(i)
+                        found = 1
+                if not found:
+                    self.community_membership.append(-1)
     
     def dim_nnz_thresholds(self, step = 100, diff_tol = 0.005):
         """Give the minimal and the maximal number of non zero values to have for a dimension to be kept and not lower the model's similarity. Taking into account the datasets MEN, WS353, SCWS and SimLex-999.

--- a/tests/test_sinr_dim_filter.py
+++ b/tests/test_sinr_dim_filter.py
@@ -35,30 +35,61 @@ class TestSinr_embeddings(unittest.TestCase):
         vec_remove=ge.InterpretableWordsModelBuilder(sinr, 'test', n_jobs=8, n_neighbors=25).build()
         
         self.vec_rm = vec_remove
+        
+        # vectors :
+        #[[0.         0.5        0.         0.         0.5       ]
+        # [0.25       0.         0.25       0.25       0.25      ]
+        # [0.         0.33333333 0.         0.33333333 0.33333333]
+        # [0.         0.33333333 0.33333333 0.         0.33333333]
+        # [0.25       0.25       0.25       0.25       0.        ]]
+        
+        # communities :
+        #[{0}, {1}, {2}, {3}, {4}]
+        
+        # community membership :
+        # [0, 1, 2, 3, 4]
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
 
     def test_remove_communities_dim_nnz(self):
-        print(self.vec_rm.vectors.toarray())
-        print(self.vec_rm.communities_sets)
-        print(self.vec_rm.community_membership)
+        # Dimension 0 is removed
         self.vec_rm.remove_communities_dim_nnz(threshold_min = 3, threshold_max = 4)
+        
         self.assertTrue((np.round(self.vec_rm.vectors.toarray(), 2) == np.round(np.array([[0.5, 0., 0., 0.5],
                                                                      [0., 0.25, 0.25, 0.25],
                                                                      [0.33333333, 0., 0.33333333, 0.33333333],
                                                                      [0.33333333, 0.33333333, 0., 0.33333333],
                                                                      [0.25, 0.25, 0.25, 0.]]), 2)).all())
+        
+        # Community at index 0 is removed
         self.assertTrue((self.vec_rm.communities_sets == [{1}, {2}, {3}, {4}]).all())
+        # Object member of the community 0 is no longer member of a community
         self.assertTrue(self.vec_rm.community_membership == [-1, 0, 1, 2, 3])
-                        
+        
+        # Current vectors :
+        #[[0.5        0.         0.         0.5       ]
+        # [0.         0.25       0.25       0.25      ]
+        # [0.33333333 0.         0.33333333 0.33333333]
+        # [0.33333333 0.33333333 0.         0.33333333]
+        # [0.25       0.25       0.25       0.        ]]
+        
+        # communities :
+        #[{1}, {2}, {3}, {4}]
+        
+        # community membership :
+        # [-1, 0, 1, 2, 3]
+        
+        # Dimensions 0 and 3 are removed
         self.vec_rm.remove_communities_dim_nnz(threshold_min = 3, threshold_max = 3)
         self.assertTrue((np.round(self.vec_rm.vectors.toarray(), 2) == np.round(np.array([[0., 0.], 
                                                                       [0.25, 0.25],
                                                                       [0., 0.33333333],
                                                                       [0.33333333, 0.],
                                                                       [0.25, 0.25]]), 2)).all())
+        # Communities at index 0 and 3 are removed
         self.assertTrue((self.vec_rm.communities_sets == [{2}, {3}]).all())
+        # Objects members of the communities 0 and 3 are no longer member of a community 
         self.assertTrue(self.vec_rm.community_membership == [-1, -1, 0, 1, -1])
 
 

--- a/tests/test_sinr_dim_filter.py
+++ b/tests/test_sinr_dim_filter.py
@@ -40,15 +40,17 @@ class TestSinr_embeddings(unittest.TestCase):
         """Tear down test fixtures, if any."""
 
     def test_remove_communities_dim_nnz(self):
-        
+        print(self.vec_rm.vectors.toarray())
+        print(self.vec_rm.communities_sets)
+        print(self.vec_rm.community_membership)
         self.vec_rm.remove_communities_dim_nnz(threshold_min = 3, threshold_max = 4)
         self.assertTrue((np.round(self.vec_rm.vectors.toarray(), 2) == np.round(np.array([[0.5, 0., 0., 0.5],
                                                                      [0., 0.25, 0.25, 0.25],
                                                                      [0.33333333, 0., 0.33333333, 0.33333333],
                                                                      [0.33333333, 0.33333333, 0., 0.33333333],
                                                                      [0.25, 0.25, 0.25, 0.]]), 2)).all())
-        self.assertTrue(self.vec_rm.communities_sets == [{1}, {2}, {3}, {4}])
-        self.assertTrue(self.vec_rm.community_membership == [1, 2, 3, 4])
+        self.assertTrue((self.vec_rm.communities_sets == [{1}, {2}, {3}, {4}]).all())
+        self.assertTrue(self.vec_rm.community_membership == [-1, 0, 1, 2, 3])
                         
         self.vec_rm.remove_communities_dim_nnz(threshold_min = 3, threshold_max = 3)
         self.assertTrue((np.round(self.vec_rm.vectors.toarray(), 2) == np.round(np.array([[0., 0.], 
@@ -56,8 +58,8 @@ class TestSinr_embeddings(unittest.TestCase):
                                                                       [0., 0.33333333],
                                                                       [0.33333333, 0.],
                                                                       [0.25, 0.25]]), 2)).all())
-        self.assertTrue(self.vec_rm.communities_sets == [{2}, {3}])
-        self.assertTrue(self.vec_rm.community_membership == [2, 3])
+        self.assertTrue((self.vec_rm.communities_sets == [{2}, {3}]).all())
+        self.assertTrue(self.vec_rm.community_membership == [-1, -1, 0, 1, -1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description**

SINr-filtered : when filtering dimensions, the communities_sets and the community_membership are now updated to match with new indexes of dimensions.

Fixes #73 Wrong community_memberships update when filtering dimensions

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules