### PR TITLE
76 preprocessing multiple documents

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,8 +27,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-runner
-        python -m spacy download en_core_web_sm
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m spacy download en_core_web_sm
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-runner
+        python -m spacy download en_core_web_sm
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/sinr/text/preprocess.py
+++ b/sinr/text/preprocess.py
@@ -35,9 +35,11 @@ class Corpus:
 
 class VRTMaker:
     """ """
-    def _get_model(self):
+    def _get_model(self, spacy_size='lg'):
         """Load a SpaCy model.
-
+        
+        :param spacy_size: Size indicator 'sm', 'md' or 'lg' (default)
+        :type spacy_size: str
 
         :returns: A spacy.Language object with the loaded pipeline.
 
@@ -45,9 +47,9 @@ class VRTMaker:
 
         """
         if self.corpus.language == "fr":
-            return spacy.load("fr_core_news_lg")
+            return spacy.load("fr_core_news_" + spacy_size)
         elif self.corpus.language == "en":
-            return spacy.load("en_core_web_lg")
+            return spacy.load("en_core_web_" + spacy_size)
 
     def _create_output(self, output_path):
         """Create the output file for the processed data.
@@ -64,7 +66,7 @@ class VRTMaker:
         corpus_output.touch()
         return corpus_output
 
-    def __init__(self, corpus: Corpus, output_path, n_jobs=1):
+    def __init__(self, corpus: Corpus, output_path, n_jobs=1, spacy_size='lg'):
         """Initialize a VRTMaker object to build VRT preprocessed corpus files.
 
         :param corpus: The corpus object to preprocess.
@@ -73,12 +75,15 @@ class VRTMaker:
         :type output_path: str
         :param n_jobs: Number of jobs for preprocessing steps, defaults to 1
         :type n_jobs: int, optional
+        :param spacy_size: Size indicator to load SpaCy model (default 'lg')
+        :type spacy_size: str
         """
         self.corpus = corpus
         self.corpus_output = self._create_output(output_path)
-        self.model = self._get_model()
+        self.model = self._get_model(spacy_size=spacy_size)
         self._with_ner_merging()
         self.n_jobs = n_jobs
+        
 
     def _open(self):
         """Open the output file.

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,104 @@
+"""Tests for `sinr_embeddings` package.
+Testing preprocessing of a textual corpus.
+"""
+
+import pytest
+import unittest
+
+import sinr.text.preprocess as ppcs
+import urllib.request
+import os
+from sklearn.datasets import fetch_20newsgroups
+
+
+class TestSinr_embeddings(unittest.TestCase):
+    """Tests for `graph_embeddings` package."""
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        txt_path = './ppcs_test.txt'
+        vrt_path = './ppcs_test.vrt'
+        doc_separator = '##D'
+        s0 = doc_separator + " At 10 a.m, in the heart of New York City, John Smith walked briskly towards the Empire State Building. "
+        text = ( s0 +
+                "As he passed by Starbucks, he grabbed a quick coffee. "
+                "He was on his way to meet Sarah Johnson, the CEO of GlobalTech, for an important business meeting. "
+                + doc_separator +
+                "Sarah Johnson, known for her sharp business acumen, was already waiting at the lobby of the iconic skyscraper. "
+                "As John entered the building, he couldn't help but feel a sense of nervous excitement. "
+                + doc_separator +
+                "The meeting room was located on the 60th floor, overlooking the bustling city below.\n"
+                "After a firm handshake and brief introductions, John and Sarah delved into discussions about potential collaborations. "
+                "The conversation flowed smoothly, with both parties expressing enthusiasm for the possibilities ahead. "
+                "By the end of the meeting, they had outlined a preliminary agreement and scheduled further negotiations for the following week. "
+                + doc_separator +
+                "With a renewed sense of optimism, John left the Empire State Building, knowing that his encounter with Sarah Johnson could mark a"
+                "significant turning point for Tech Innovations Inc.")
+        with open(txt_path, 'w+') as file:
+            file.write(text)
+        file.close()
+        self.txt_path = txt_path
+        self.vrt_path = vrt_path
+        self.n_doc = 4
+        self.n_sent = 10
+        self.doc_separator = doc_separator
+        self.s0 = s0
+        
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+        os.remove(self.txt_path)
+        os.remove(self.vrt_path)
+    
+    def test_doc_separator(self):
+        """Testing if the preprocessed datas have the right number of documents"""
+        vrt_maker = ppcs.VRTMaker(ppcs.Corpus(ppcs.Corpus.REGISTER_WEB,
+                                  ppcs.Corpus.LANGUAGE_EN,
+                                  self.txt_path),
+                                  ".", n_jobs=8)
+        vrt_maker.do_txt_to_vrt(separator=self.doc_separator)
+        docs = ppcs.extract_text(self.vrt_path, lemmatize=True, min_freq=1)
+        self.assertTrue(len(docs) == self.n_doc)
+        
+    def test_sentence_separator(self):
+        """Testing if the preprocessed datas have the right number of sentences"""
+        vrt_maker = ppcs.VRTMaker(ppcs.Corpus(ppcs.Corpus.REGISTER_WEB,
+                                  ppcs.Corpus.LANGUAGE_EN,
+                                  self.txt_path),
+                                  ".", n_jobs=8)
+        vrt_maker.do_txt_to_vrt()
+        sentences = ppcs.extract_text(self.vrt_path, lemmatize=True, min_freq=1)
+        self.assertTrue(len(sentences) == self.n_sent)
+    
+    def test_preprocessed(self):
+        """Testing the preprocessing by default on the first sentence"""
+        vrt_maker = ppcs.VRTMaker(ppcs.Corpus(ppcs.Corpus.REGISTER_WEB,
+                                  ppcs.Corpus.LANGUAGE_EN,
+                                  self.txt_path),
+                                  ".", n_jobs=8)
+        vrt_maker.do_txt_to_vrt()
+        sentences = ppcs.extract_text(self.vrt_path, min_freq=1)
+        
+        doc = vrt_maker.model(self.s0)
+        s = sentences[0]
+        ok = list()
+        ind = -1
+        for i,token in enumerate(doc):
+            if not token.is_punct and not token.is_stop and not token.is_digit and not token.like_num:
+                if token.ent_type_ == '':
+                    if len(token.lemma_) > 3:
+                        ind += 1
+                        ok.append(token.lemma_.lower() == s[ind])
+                else:
+                    if len(token.text) > 3:
+                        ind += 1
+                        if ' ' in token.text:
+                            ok.append(token.text.replace(' ', '_').lower() == s[ind])
+                        else:
+                            ok.append(token.text.lower() == s[ind])
+                            
+        self.assertTrue(False not in ok)
+            
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -55,7 +55,7 @@ class TestSinr_embeddings(unittest.TestCase):
         vrt_maker = ppcs.VRTMaker(ppcs.Corpus(ppcs.Corpus.REGISTER_WEB,
                                   ppcs.Corpus.LANGUAGE_EN,
                                   self.txt_path),
-                                  ".", n_jobs=8)
+                                  ".", n_jobs=8, spacy_size='sm')
         vrt_maker.do_txt_to_vrt(separator=self.doc_separator)
         docs = ppcs.extract_text(self.vrt_path, lemmatize=True, min_freq=1)
         self.assertTrue(len(docs) == self.n_doc)
@@ -65,7 +65,7 @@ class TestSinr_embeddings(unittest.TestCase):
         vrt_maker = ppcs.VRTMaker(ppcs.Corpus(ppcs.Corpus.REGISTER_WEB,
                                   ppcs.Corpus.LANGUAGE_EN,
                                   self.txt_path),
-                                  ".", n_jobs=8)
+                                  ".", n_jobs=8, spacy_size='sm')
         vrt_maker.do_txt_to_vrt()
         sentences = ppcs.extract_text(self.vrt_path, lemmatize=True, min_freq=1)
         self.assertTrue(len(sentences) == self.n_sent)
@@ -75,7 +75,7 @@ class TestSinr_embeddings(unittest.TestCase):
         vrt_maker = ppcs.VRTMaker(ppcs.Corpus(ppcs.Corpus.REGISTER_WEB,
                                   ppcs.Corpus.LANGUAGE_EN,
                                   self.txt_path),
-                                  ".", n_jobs=8)
+                                  ".", n_jobs=8, spacy_size='sm')
         vrt_maker.do_txt_to_vrt()
         sentences = ppcs.extract_text(self.vrt_path, min_freq=1)
         


### PR DESCRIPTION
**Description**

Adding 'separator' parameter to sinr.text.preprocess.VRTMaker.do_text_to_vrt method to preprocess sentence by sentence or document by document.

Fixes #76 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**How Has This Been Tested?**

In tests.test_preprocess:
- [x] Testing preprocessing document by document
- [x] Testing preprocessing sentence by sentence
- [x] Testing default preprocessing

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules