### PR TITLE
get_dimension_stereotypes on removed community fixed

### DIFF
--- a/sinr/graph_embeddings.py
+++ b/sinr/graph_embeddings.py
@@ -1235,7 +1235,7 @@ class SINrVectors(object):
     def get_dimension_stereotypes(self, obj, topk=5):
         """Get the words with the highest values on dimension obj.
 
-        :param obj: id of a dimension, or label of a word (then turned into the id of its community)
+        :param obj: id of a word, or label of a word (then turned into the id of its community)
         :type obj: int or str
         :param topk: topk value to consider on the dimension (Default value = 5)
         :type topk: int
@@ -1243,7 +1243,10 @@ class SINrVectors(object):
 
         """
         index = self._get_index(obj)
-        return self.get_dimension_stereotypes_idx(self.get_community_membership(index), topk)
+        if self.community_membership[index] != -1:
+            return self.get_dimension_stereotypes_idx(self.get_community_membership(index), topk)
+        else:
+            raise DimensionFilteredException("'"+self.vocab[index] + "' (id "+str(index)+') is member of a community which got removed by filtering.')
 
     def get_dimension_stereotypes_idx(self, idx, topk=5):
         """Get the indices of the words with the highest values on dimension obj.
@@ -1469,3 +1472,7 @@ class SINrVectors(object):
         f = open(self.name + "_light.pk", 'wb')
         pk.dump(data,f)
         f.close()
+
+class DimensionFilteredException(Exception):
+    """Exception raised when trying to access a dimension removed by filtering. """
+    pass


### PR DESCRIPTION
**Description**

When calling get_dimension_stereotypes on a member of  a removed community, a DimensionFilteredException is raised.

Fixes #81 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules