### PR TITLE
Add analogy by k and by category

### DIFF
--- a/tests/test_sinr_evaluate.py
+++ b/tests/test_sinr_evaluate.py
@@ -78,6 +78,11 @@ class MockSINrVectors:
         self.vocab = vocab
         self.vectors = csr_matrix(vectors)
         
+    def get_my_vector(self, word):
+        if word in self.vocab:
+            return self.vectors[self.vocab.index(word)]
+        raise ValueError(f"Word '{word}' not found in vocab.")
+        
 class TestAnalogyFunctions(unittest.TestCase):
     """Tests for analogy functions."""
     def setUp(self):

--- a/tests/test_sinr_evaluate.py
+++ b/tests/test_sinr_evaluate.py
@@ -80,7 +80,8 @@ class MockSINrVectors:
         
     def get_my_vector(self, word):
         if word in self.vocab:
-            return self.vectors[self.vocab.index(word)]
+            vec = self.vectors[self.vocab.index(word)]
+            return vec.toarray().flatten()
         raise ValueError(f"Word '{word}' not found in vocab.")
         
 class TestAnalogyFunctions(unittest.TestCase):


### PR DESCRIPTION
Files changed :
-sint/text/evaluate.py
-tests/test_sinr_evaluate

New functions :
- best_predicted_word_k
- eval_analogy_k
- eval_analogy_by_category_k
- plot_global_error_rates
- plot_category_error_rates

Description :
- best_predicted_word_k : Predict the best word for the analogy A is to B as C is to D with k best words.
- eval_analogy_k : Compare the predicted with the expected word with k best words.
- eval_analogy_by_category_k : Evaluate analogy by category with k best words
- plot_global_error_rates : Plot global error rates for different values of k
- plot_category_error_rates : Plot error rates by category for different values of k

Add Unit tests for best_predicted_word_k and eval_analogy_k functions

New import : tempfile, matplotlib